### PR TITLE
Rails 3 escaping

### DIFF
--- a/lib/table_helper/footer.rb
+++ b/lib/table_helper/footer.rb
@@ -33,7 +33,7 @@ module TableHelper
       html_options = @html_options.dup
       html_options[:style] = "display: none; #{html_options[:style]}".strip if table.empty? && hide_when_empty
       
-      content_tag(tag_name, content, html_options)
+      content_tag(tag_name, content, html_options, false)
     end
     
     private

--- a/lib/table_helper/header.rb
+++ b/lib/table_helper/header.rb
@@ -94,7 +94,7 @@ module TableHelper
       html_options = @html_options.dup
       html_options[:style] = 'display: none;' if table.empty? && hide_when_empty
       
-      content_tag(tag_name, content, html_options)
+      content_tag(tag_name, content, html_options, false)
     end
     
     private

--- a/lib/table_helper/html_element.rb
+++ b/lib/table_helper/html_element.rb
@@ -25,7 +25,7 @@ module TableHelper
     
     # Generates the html representing this element
     def html
-      content_tag(tag_name, content, @html_options)
+      content_tag(tag_name, content, @html_options, false)
     end
     
     private


### PR DESCRIPTION
When upgrading my app to Rails 3 I encountered an issue with collection_table escaping the generated content. I tried various ways of working around this, and none worked: (a) calling html_safe against each of the strings I passed to collection_table, (b) using <%=raw in the first line, and (c) putting each line into its own erb <%=raw %> line. 

The solution that worked was to modify content_tag calls in table_helper to disable the escaping.

Here are some of the references I used:
http://stackoverflow.com/questions/3863844/rails-how-to-build-table-in-helper-using-content-tag/
http://asciicasts.com/episodes/204-xss-protection-in-rails-3/
http://railsdispatch.com/posts/security/
http://yehudakatz.com/2010/02/01/safebuffers-and-rails-3-0/
